### PR TITLE
fixed target port in controller-service-prometheus.yaml

### DIFF
--- a/lessons/013/04-ingress-nginx/controller-service-prometheus.yaml
+++ b/lessons/013/04-ingress-nginx/controller-service-prometheus.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
     - name: prometheus
       port: 10254
-      targetPort: prometheus
+      targetPort: 10254
   selector:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/component: controller


### PR DESCRIPTION
It didn't work for me without specifying the port as a number - the service could not find the pods.